### PR TITLE
Feature/remove revit server root path

### DIFF
--- a/AltecSystems.Revit.ServerExport/AltecSystems.Revit.ServerExport.csproj
+++ b/AltecSystems.Revit.ServerExport/AltecSystems.Revit.ServerExport.csproj
@@ -160,6 +160,5 @@
       <Install>false</Install>
     </BootstrapperPackage>
   </ItemGroup>
-  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/AltecSystems.Revit.ServerExport/MainWindow.xaml
+++ b/AltecSystems.Revit.ServerExport/MainWindow.xaml
@@ -42,14 +42,6 @@
             <StackPanel>
                 <DockPanel>
                     <Label
-                        Style="{StaticResource defaultLabelStyle}"
-                        Content="Путь на сервере:" />
-                    <TextBox
-                        Style="{StaticResource defaultTextBoxStyle}"
-                        Text="{Binding Settings.RevitServerRootPath}" />
-                </DockPanel>
-                <DockPanel>
-                    <Label
                         Content="Cохранить в:"
                         Style="{StaticResource defaultLabelStyle}" />
                     <TextBox

--- a/AltecSystems.Revit.ServerExport/Models/ConnectionModel.cs
+++ b/AltecSystems.Revit.ServerExport/Models/ConnectionModel.cs
@@ -3,7 +3,6 @@
     internal class ConnectionModel
     {
         public string ServerHost { get; set; }
-        public string RevitServerRootPath { get; set; }
         public string RevitVersion { get; set; }
     }
 }

--- a/AltecSystems.Revit.ServerExport/Models/ProgressModel.cs
+++ b/AltecSystems.Revit.ServerExport/Models/ProgressModel.cs
@@ -42,5 +42,11 @@ namespace AltecSystems.Revit.ServerExport.Models
         public Visibility IsVisibility { get => _isVisible; set => SetField(ref _isVisible, value, nameof(IsVisibility)); }
 
         public string StatusText => IsIndeterminate ? "Ожидание загрузки" : $"Загружено {CurrentProgress} из {Max}";
+
+        public void Clear()
+        {
+            CurrentProgress = 0;
+            Max = 0;
+        }
     }
 }

--- a/AltecSystems.Revit.ServerExport/Models/SettingsModel.cs
+++ b/AltecSystems.Revit.ServerExport/Models/SettingsModel.cs
@@ -6,17 +6,16 @@ namespace AltecSystems.Revit.ServerExport.Models
 {
     internal class SettingsModel : NotifyPropertyChangedBase
     {
-        private string _revitServerRootPath;
         private string _savePath;
         private string _serverHost;
+        private string _currentSelectionServerVersion;
 
-        public string RevitServerRootPath { get => _revitServerRootPath; set => SetField(ref _revitServerRootPath, value, nameof(RevitServerRootPath)); }
         public string SavePath { get => _savePath; set => SetField(ref _savePath, value, nameof(SavePath)); }
         public string ServerHost { get => _serverHost; set => SetField(ref _serverHost, value, nameof(ServerHost)); }
 
         [JsonIgnore]
         public List<string> ServerVersion { get; } = new List<string> { "2012", "2013", "2014", "2015", "2016", "2017", "2018", "2019", "2020", "2021", "2022" };
 
-        public string CurrentSelectionServerVersion { get; set; }
+        public string CurrentSelectionServerVersion { get => _currentSelectionServerVersion; set => SetField(ref _currentSelectionServerVersion, value, nameof(CurrentSelectionServerVersion)); }
     }
 }

--- a/AltecSystems.Revit.ServerExport/ServerExportViewModel.cs
+++ b/AltecSystems.Revit.ServerExport/ServerExportViewModel.cs
@@ -1,6 +1,8 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.IO;
 using System.Linq;
 using System.ServiceModel;
 using System.Windows;
@@ -8,12 +10,12 @@ using System.Windows.Input;
 using AltecSystems.Revit.ServerExport.Command;
 using AltecSystems.Revit.ServerExport.Models;
 using AltecSystems.Revit.ServerExport.Services;
+using Autodesk.RevitServer.Enterprise.Common.ClientServer.Helper.Exceptions;
 
 namespace AltecSystems.Revit.ServerExport
 {
     internal class ServerExportViewModel : NotifyPropertyChangedBase
     {
-        public ICommand DestinCommand { get; }
         public ICommand ExportCommand { get; }
         public ICommand LoadModelCommand { get; }
 
@@ -30,7 +32,6 @@ namespace AltecSystems.Revit.ServerExport
             _settingsManager = new SettingsManager();
             Settings = _settingsManager.GetSettings();
             Nodes = new ObservableCollection<Node>();
-            DestinCommand = new RelayCommand(null, null);
             ExportCommand = new RelayCommand(Export, null);
             LoadModelCommand = new RelayCommand(StartLoadModelAsync, null);
             Progress = new ProgressModel();
@@ -48,11 +49,11 @@ namespace AltecSystems.Revit.ServerExport
                 {
                     export.Export();
                 }
-                catch (FaultException)
+                catch (FaultException ex)
                 {
                     MessageBox.Show("Произошла ошибка при выгрузке. Проверьте версию revit");
                 }
-                catch (Exception)
+                catch (Exception ex)
                 {
                     MessageBox.Show("Произошла ошибка при выгрузке.");
                 }
@@ -82,7 +83,7 @@ namespace AltecSystems.Revit.ServerExport
             return Path.Combine(Settings.SavePath, modelPath);
         }
 
-        private void Settings_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        private void Settings_PropertyChanged(object sender, PropertyChangedEventArgs e)
         {
             _settingsManager.SaveSettings(Settings);
         }

--- a/AltecSystems.Revit.ServerExport/ServerExportViewModel.cs
+++ b/AltecSystems.Revit.ServerExport/ServerExportViewModel.cs
@@ -95,8 +95,23 @@ namespace AltecSystems.Revit.ServerExport
             Progress.IsVisibility = Visibility.Visible;
             Progress.IsIndeterminate = true;
 
-            var loader = new ProxyModelLoader(Settings);
-            await loader.LoadModelAsync(Nodes, Progress);
+            try
+            {
+                var loader = new ProxyModelLoader(Settings);
+                await loader.LoadModelAsync(Nodes, Progress);
+            }
+            catch (ProxyGenerationException ex)
+            {
+                MessageBox.Show($"Не удалось создать соединение с revit server версии {Settings.CurrentSelectionServerVersion}");
+            }
+            catch (ArgumentException ex)
+            {
+                MessageBox.Show(ex.Message);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(ex.Message);
+            }
 
             Progress.IsVisibility = Visibility.Collapsed;
         }

--- a/AltecSystems.Revit.ServerExport/ServerExportViewModel.cs
+++ b/AltecSystems.Revit.ServerExport/ServerExportViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -89,6 +89,9 @@ namespace AltecSystems.Revit.ServerExport
 
         private async void StartLoadModelAsync(object commandParam)
         {
+            Nodes.Clear();
+            Progress.Clear();
+
             Progress.IsVisibility = Visibility.Visible;
             Progress.IsIndeterminate = true;
 

--- a/AltecSystems.Revit.ServerExport/ServerExportViewModel.cs
+++ b/AltecSystems.Revit.ServerExport/ServerExportViewModel.cs
@@ -79,7 +79,7 @@ namespace AltecSystems.Revit.ServerExport
 
         private string GetSavePath(string modelPath)
         {
-            return modelPath.Replace(Settings.RevitServerRootPath, Settings.SavePath);
+            return Path.Combine(Settings.SavePath, modelPath);
         }
 
         private void Settings_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)

--- a/AltecSystems.Revit.ServerExport/Services/ExportModels.cs
+++ b/AltecSystems.Revit.ServerExport/Services/ExportModels.cs
@@ -128,7 +128,8 @@ namespace AltecSystems.Revit.ServerExport.Services
 
             IClientProxy<IModelService> bufferedProxy = GetBufferedProxy();
             IModelService proxy = bufferedProxy.Proxy;
-            return proxy.LockData(sessionToken, lockOptions, bAllowBecomeNonExclusive: true, localModelVersion, out creationDate);
+
+            return proxy.LockData(sessionToken, lockOptions, bAllowBecomeNonExclusive: false, localModelVersion, out creationDate);
         }
 
         private ServiceModelSessionToken CreateServiceModelSessionToken()
@@ -141,11 +142,6 @@ namespace AltecSystems.Revit.ServerExport.Services
         }
 
         private IClientProxy<IModelService> GetStreamedProxy()
-        {
-            return ProxyProvider.CreateProxyInstance(_credential.RevitVersion).GetStreamedProxy<IModelService>(_credential.HostIp);
-        }
-
-        private IClientProxy<IModelService> GetRoutedProxy()
         {
             return ProxyProvider.CreateProxyInstance(_credential.RevitVersion).GetStreamedProxy<IModelService>(_credential.HostIp);
         }

--- a/AltecSystems.Revit.ServerExport/Services/ProxyModelLoader.cs
+++ b/AltecSystems.Revit.ServerExport/Services/ProxyModelLoader.cs
@@ -1,4 +1,4 @@
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -27,7 +27,10 @@ namespace AltecSystems.Revit.ServerExport.Services
             var foldersAndModels = await Task<FoldersAndModels>.Factory.StartNew(() =>
             {
                 var sessionToken = SessionTokenGenerator.CreateServiceSessionToken();
-                _bufferedProxy.ListSubFoldersAndModels(sessionToken, relativeFolderPath, out var folders, out var models);
+                if (!_bufferedProxy.ListSubFoldersAndModels(sessionToken, relativeFolderPath, out var folders, out var models))
+                {
+                    throw new System.ArgumentException("Не удалось получить папки и модели.");
+                }
                 var result = new FoldersAndModels(ParseList(folders), ParseList(models));
                 return result;
             });

--- a/AltecSystems.Revit.ServerExport/Services/ProxyModelLoader.cs
+++ b/AltecSystems.Revit.ServerExport/Services/ProxyModelLoader.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -18,7 +18,7 @@ namespace AltecSystems.Revit.ServerExport.Services
 
         public ProxyModelLoader(SettingsModel settings)
         {
-            _connectionModel = new ConnectionModel() { RevitServerRootPath = settings.RevitServerRootPath, ServerHost = settings.ServerHost, RevitVersion = settings.CurrentSelectionServerVersion };
+            _connectionModel = new ConnectionModel() { ServerHost = settings.ServerHost, RevitVersion = settings.CurrentSelectionServerVersion };
             _bufferedProxy = GetBufferedProxy().Proxy;
         }
 
@@ -67,8 +67,12 @@ namespace AltecSystems.Revit.ServerExport.Services
             }
             foreach (var item in foldersAndModels.SubFolders)
             {
-                var node = new Node() { Text = item, Parent = parent, Path = path + "\\" + item };
                 string url = path + "\\" + item;
+                if (string.IsNullOrWhiteSpace(path))
+                {
+                    url = item;
+                }
+                var node = new Node() { Text = item, Parent = parent, Path = url };
 
                 nodes.Add(node);
                 progress.CurrentProgress++;
@@ -78,7 +82,7 @@ namespace AltecSystems.Revit.ServerExport.Services
 
         public async Task LoadModelAsync(ObservableCollection<Node> nodes, ProgressModel progress)
         {
-            await LoadModelAsync(nodes, null, _connectionModel.RevitServerRootPath, progress);
+            await LoadModelAsync(nodes, null, "", progress);
         }
     }
 }

--- a/AltecSystems.Revit.ServerExport/Services/SettingsManager.cs
+++ b/AltecSystems.Revit.ServerExport/Services/SettingsManager.cs
@@ -52,7 +52,6 @@ namespace AltecSystems.Revit.ServerExport.Services
             return new SettingsModel()
             {
                 SavePath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
-                RevitServerRootPath = @"E:\ProgramData\Revit server",
                 ServerHost = "192.168.1.10",
             };
         }


### PR DESCRIPTION
Удалено поле "RevitServerRootPath". Благодаря чему теперь не нужно указывать "путь на сервере". 